### PR TITLE
Fix a tipo in the cpu value of protanopia.

### DIFF
--- a/python/peacock.py
+++ b/python/peacock.py
@@ -9,7 +9,7 @@ class ColorBlindConverter(object):
     def __init__(self, inputimage):
         self.powGammaLookup = np.power(np.linspace(0,256,256)/256, 2.2)
         self.conversion_coeffs = {
-            'p': {'cpu': 0.753, 'cpv':  0.265, 'am': 1.273463, 'ayi': -0.073894},
+            'p': {'cpu': 0.735, 'cpv':  0.265, 'am': 1.273463, 'ayi': -0.073894},
             'd': {'cpu': 1.140, 'cpv': -0.140, 'am': 0.968437, 'ayi':  0.003331},
             't': {'cpu': 0.171, 'cpv': -0.003, 'am': 0.062921, 'ayi':  0.292119}}
         self.image = Image.open(inputimage)


### PR DESCRIPTION
Hi! I was comparing color blindness simulation methods and found a difference between peacock and the original JS code from MaPePeR. The cpu value for protanopia has a tipo, it is set to 0.735, which was incorrectly 0.753 in peacock. See https://github.com/MaPePeR/jsColorblindSimulator/blob/0d54d90cbf3cbe070ec3da8d7aea795d760a1da0/hcirn_colorblind_simulation.js#L24 .

It does not make a huge difference in practice, but well, does not hurt :)

